### PR TITLE
Fix typo (`yoru` => `your`)

### DIFF
--- a/docs/prevent_browser_quitting.html
+++ b/docs/prevent_browser_quitting.html
@@ -7,6 +7,6 @@
   </script>
 </head>
 <body>
-  <h1>Leave this window open to ensure that you get a prompt before quitting your browser. Click "Stay on page" to prevent quitting yoru browser.</h1>
+  <h1>Leave this window open to ensure that you get a prompt before quitting your browser. Click "Stay on page" to prevent quitting your browser.</h1>
 </body>
 </html>


### PR DESCRIPTION
Hit `Ctrl-Q` by mistake for the umpteenth time.

Looked around for solutions.

Saw your comment @ https://bugzilla.mozilla.org/show_bug.cgi?id=52821 and the subsequent reply.

Before the 200 million arrive, probably a good idea to fix this typo.

Unless `yoru` is a "thing" -- and in that case, I will most happily trash this PR!

And finally, thanks for this useful resource.